### PR TITLE
Build for Debian 12 (remove Debian 10)

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, debian-buster, debian-bullseye]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, debian-bullseye, debian-bookworm]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
From https://www.debian.org/releases/buster/

> Debian 10 has been superseded by Debian 11 (bullseye). Security updates
> have been discontinued as of June 30th, 2022.