### PR TITLE
Parse AMQP frames and send one per WS frame

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -1,2 +1,6 @@
 version: 2.0
-shards: {}
+shards:
+  amq-protocol:
+    git: https://github.com/cloudamqp/amq-protocol.cr.git
+    version: 1.1.14
+

--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,10 @@ targets:
   websocket-tcp-relay:
     main: src/websocket-tcp-relay.cr
 
+dependencies:
+  amq-protocol:
+    github: cloudamqp/amq-protocol.cr
+
 crystal: 1.0.0
 
 license: Apache-2.0

--- a/src/websocket-tcp-relay/websocket_relay.cr
+++ b/src/websocket-tcp-relay/websocket_relay.cr
@@ -13,7 +13,6 @@ module WebSocketTCPRelay
         puts "#{remote_addr} connected"
         tcp_socket = TCPSocket.new(host, port, dns_timeout: 5, connect_timeout: 15)
         tcp_socket.tcp_nodelay = true
-        tcp_socket.read_buffering = false
         tcp_socket.keepalive = true
         tcp_socket.tcp_keepalive_idle = 60
         tcp_socket.tcp_keepalive_interval = 10
@@ -22,7 +21,6 @@ module WebSocketTCPRelay
           if ctx = tls_ctx
             OpenSSL::SSL::Socket::Client.new(tcp_socket, ctx, hostname: host).tap do |c|
               c.sync_close = true
-              c.read_buffering = false
             end
           else
             tcp_socket

--- a/src/websocket-tcp-relay/websocket_relay.cr
+++ b/src/websocket-tcp-relay/websocket_relay.cr
@@ -14,6 +14,10 @@ module WebSocketTCPRelay
         tcp_socket = TCPSocket.new(host, port, dns_timeout: 5, connect_timeout: 15)
         tcp_socket.tcp_nodelay = true
         tcp_socket.read_buffering = false
+        tcp_socket.keepalive = true
+        tcp_socket.tcp_keepalive_idle = 60
+        tcp_socket.tcp_keepalive_interval = 10
+        tcp_socket.tcp_keepalive_count = 3
         socket =
           if ctx = tls_ctx
             OpenSSL::SSL::Socket::Client.new(tcp_socket, ctx, hostname: host).tap do |c|


### PR DESCRIPTION
AMQP frames can be split up over multiple WS frames, which forced [amqp-client.js](https://github.com/cloudamqp/amqp-client.js) to do complicated parsing of WS frames: https://github.com/cloudamqp/amqp-client.js/blob/4e0fdfcd134b00ac079424164032722cbccb0333/src/amqp-websocket-client.ts#L95-L112

This PR fixes that and parses full AMQP frames and send them in separate WS frames. 

Fixes #18