### PR TITLE
Fix dependencies for Noble package

### DIFF
--- a/build/deb
+++ b/build/deb
@@ -6,6 +6,14 @@ architecture=$(dpkg --print-architecture)
 shards build --production --release
 strip bin/*
 
+# dpkg-shlibdeps requires presence of `debian/control`
+apt-get update && apt-get install dpkg-dev --yes
+mkdir debian
+touch debian/control
+shlib_depends=$(dpkg-shlibdeps -O -e bin/* 2> /dev/null);
+depends=${shlib_depends#shlibs:Depends=}
+rm -r debian
+
 mkdir debroot
 cd debroot || exit 1
 
@@ -90,7 +98,7 @@ Homepage: https://github.com/cloudamqp/websocket-tcp-relay
 Section: net
 Priority: optional
 Architecture: $architecture
-Depends: $(ldd ../bin/* | awk '/=>/ {print $3}' | xargs dpkg -S | awk -F: "/$(dpkg --print-architecture)/ { print \$1 }" | sort -u | paste -sd,)
+Depends: $depends
 Installed-Size: $(du -ks usr/ | cut -f 1)
 Maintainer: CloudAMQP Team <contact@cloudamqp.com>
 Description: Expose any TCP server as a WebSocket server


### PR DESCRIPTION
Under 24.04, `dpkg -S` can't resolve the path from the third field:

```
root@b83b32fa6a75:/# ldd /usr/bin/ls
	linux-vdso.so.1 (0x0000ffff81767000)
	libselinux.so.1 => /lib/aarch64-linux-gnu/libselinux.so.1 (0x0000ffff816a0000)
	libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffff814e0000)
	/lib/ld-linux-aarch64.so.1 (0x0000ffff8172a000)
	libpcre2-8.so.0 => /lib/aarch64-linux-gnu/libpcre2-8.so.0 (0x0000ffff81430000)

root@b83b32fa6a75:/# dpkg -S /lib/aarch64-linux-gnu/libc.so.6
dpkg-query: no path found matching pattern /lib/aarch64-linux-gnu/libc.so.6
```

This leads to an empty dependency list for Noble (and for Debian 12/Bookworm it renders a partial list).

However, using the first field leads to another problem:

```
root@b83b32fa6a75:/# dpkg -S libc.so.6
libc6-dev:arm64: /usr/share/gdb/auto-load/lib/aarch64-linux-gnu/libc.so.6-gdb.py
libc6:arm64: /usr/lib/aarch64-linux-gnu/libc.so.6
```

I.e. we find the dev package for libc6.

Let's use [dpkg-shlibdeps](https://manpages.ubuntu.com/manpages/noble/man1/dpkg-shlibdeps.1.html) instead.

---

I verified this works for all sources by adding a step: `RUN dpkg -I $(find . -name *.deb)` and inspecting the output.
