### PR TITLE
Add support for Sec-WebSocket-Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Usage: websocket-tcp-relay [arguments]
     --tls-cert=PATH                  TLS certificate + chain (default ./certs/fullchain.pem)
     --tls-key=PATH                   TLS certificate key (default ./certs/privkey.pem)
     -P, --proxy-protocol             If the upstream expects the PROXY protocol (default false)
+    --sub-protocols=protocols        Comma separated list of protocols to accept in Sec-WebSocket-Protocol
     -w PATH, --webroot=PATH          Directory from which to serve static content (default ./webroot)
     -c PATH, --config=PATH           Config file
     -v, --version                    Display version number

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,2 @@
 require "spec"
-require "../src/websocket-tcp-relay/websocket_relay"
+require "../src/websocket-tcp-relay/*"

--- a/spec/websocket-tcp-relay/websocket-protocol-handler_spec.cr
+++ b/spec/websocket-tcp-relay/websocket-protocol-handler_spec.cr
@@ -1,0 +1,99 @@
+require "http"
+require "../spec_helper"
+
+def with_relay(protocols : Enumerable(String) = Iterator(String).empty, **kwargs, &)
+  TCPServer.open(0) do |us| # start an upstream to get rid of errors
+    relay_args = {
+      host:           us.local_address.address,
+      port:           us.local_address.port,
+      tls:            false,
+      proxy_protocol: false,
+    }.merge(kwargs)
+    relay = WebSocketTCPRelay::WebSocketRelay.new(**relay_args)
+    protocol_handler = WebSocketTCPRelay::WebSocketProtocolHandler.new(protocols)
+    TCPServer.open(0) do |server|
+      http = HTTP::Server.new({protocol_handler, relay})
+      http.bind server
+      spawn { http.listen }
+      Fiber.yield
+      TCPSocket.open(server.local_address.address, server.local_address.port) do |socket|
+        yield socket
+      end
+    ensure
+      http.try &.close
+    end
+  end
+end
+
+describe WebSocketTCPRelay::WebSocketProtocolHandler do
+  describe "Sec-WebSocket-Protocol" do
+    it "should not be set if no protocol configured" do
+      with_relay do |socket|
+        headers : HTTP::Headers = HTTP::Headers.new
+        headers["Connection"] = "Upgrade"
+        headers["Upgrade"] = "websocket"
+        headers["Sec-WebSocket-Version"] = "13"
+        headers["Sec-WebSocket-Key"] = "random secret"
+
+        handshake = HTTP::Request.new("GET", "/", headers)
+        handshake.to_io(socket)
+        handshake_response = HTTP::Client::Response.from_io(socket, ignore_body: true)
+        response_headers = handshake_response.headers
+        response_headers.has_key?("Sec-WebSocket-Protocol").should be_false
+      end
+    end
+
+    it "should be set if requested value is configured" do
+      with_relay(protocols: {"amqp"}) do |socket|
+        headers : HTTP::Headers = HTTP::Headers.new
+        headers["Connection"] = "Upgrade"
+        headers["Upgrade"] = "websocket"
+        headers["Sec-WebSocket-Version"] = "13"
+        headers["Sec-WebSocket-Key"] = "random secret"
+        headers["Sec-WebSocket-Protocol"] = "amqp"
+
+        handshake = HTTP::Request.new("GET", "/", headers)
+        handshake.to_io(socket)
+        handshake_response = HTTP::Client::Response.from_io(socket, ignore_body: true)
+        response_headers = handshake_response.headers
+        response_headers.has_key?("Sec-WebSocket-Protocol").should be_true
+        response_headers["Sec-WebSocket-Protocol"].should eq "amqp"
+      end
+    end
+
+    it "should be set if requested value is one of many configured" do
+      with_relay(protocols: {"mqtt", "amqp", "smtp"}) do |socket|
+        headers : HTTP::Headers = HTTP::Headers.new
+        headers["Connection"] = "Upgrade"
+        headers["Upgrade"] = "websocket"
+        headers["Sec-WebSocket-Version"] = "13"
+        headers["Sec-WebSocket-Key"] = "random secret"
+        headers["Sec-WebSocket-Protocol"] = "amqp"
+
+        handshake = HTTP::Request.new("GET", "/", headers)
+        handshake.to_io(socket)
+        handshake_response = HTTP::Client::Response.from_io(socket, ignore_body: true)
+        response_headers = handshake_response.headers
+        response_headers.has_key?("Sec-WebSocket-Protocol").should be_true
+        response_headers["Sec-WebSocket-Protocol"].should eq "amqp"
+      end
+    end
+
+    it "should not be set if requested value is not configured" do
+      with_relay(protocols: {"amqp"}) do |socket|
+        headers : HTTP::Headers = HTTP::Headers.new
+        headers["Connection"] = "Upgrade"
+        headers["Upgrade"] = "websocket"
+        headers["Sec-WebSocket-Version"] = "13"
+        headers["Sec-WebSocket-Key"] = "random secret"
+        headers["Sec-WebSocket-Protocol"] = "mqtt"
+
+        handshake = HTTP::Request.new("GET", "/", headers)
+        handshake.to_io(socket)
+        handshake_response = HTTP::Client::Response.from_io(socket, ignore_body: true)
+        response_headers = handshake_response.headers
+        response_headers.has_key?("Sec-WebSocket-Protocol").should be_false
+      end
+    end
+  end
+end

--- a/spec/websocket-tcp-relay/websocket-protocol-handler_spec.cr
+++ b/spec/websocket-tcp-relay/websocket-protocol-handler_spec.cr
@@ -9,10 +9,11 @@ def with_relay(protocols : Enumerable(String) = Iterator(String).empty, **kwargs
       tls:            false,
       proxy_protocol: false,
     }.merge(kwargs)
-    relay = WebSocketTCPRelay::WebSocketRelay.new(**relay_args)
     protocol_handler = WebSocketTCPRelay::WebSocketProtocolHandler.new(protocols)
     TCPServer.open(0) do |server|
-      http = HTTP::Server.new({protocol_handler, relay})
+      http = HTTP::Server.new({protocol_handler}) do |ctx|
+        ctx.response.status = HTTP::Status::NO_CONTENT
+      end
       http.bind server
       spawn { http.listen }
       Fiber.yield
@@ -29,13 +30,7 @@ describe WebSocketTCPRelay::WebSocketProtocolHandler do
   describe "Sec-WebSocket-Protocol" do
     it "should not be set if no protocol configured" do
       with_relay do |socket|
-        headers : HTTP::Headers = HTTP::Headers.new
-        headers["Connection"] = "Upgrade"
-        headers["Upgrade"] = "websocket"
-        headers["Sec-WebSocket-Version"] = "13"
-        headers["Sec-WebSocket-Key"] = "random secret"
-
-        handshake = HTTP::Request.new("GET", "/", headers)
+        handshake = HTTP::Request.new("GET", "/")
         handshake.to_io(socket)
         handshake_response = HTTP::Client::Response.from_io(socket, ignore_body: true)
         response_headers = handshake_response.headers
@@ -46,10 +41,6 @@ describe WebSocketTCPRelay::WebSocketProtocolHandler do
     it "should be set if requested value is configured" do
       with_relay(protocols: {"amqp"}) do |socket|
         headers : HTTP::Headers = HTTP::Headers.new
-        headers["Connection"] = "Upgrade"
-        headers["Upgrade"] = "websocket"
-        headers["Sec-WebSocket-Version"] = "13"
-        headers["Sec-WebSocket-Key"] = "random secret"
         headers["Sec-WebSocket-Protocol"] = "amqp"
 
         handshake = HTTP::Request.new("GET", "/", headers)
@@ -64,10 +55,6 @@ describe WebSocketTCPRelay::WebSocketProtocolHandler do
     it "should be set if requested value is one of many configured" do
       with_relay(protocols: {"mqtt", "amqp", "smtp"}) do |socket|
         headers : HTTP::Headers = HTTP::Headers.new
-        headers["Connection"] = "Upgrade"
-        headers["Upgrade"] = "websocket"
-        headers["Sec-WebSocket-Version"] = "13"
-        headers["Sec-WebSocket-Key"] = "random secret"
         headers["Sec-WebSocket-Protocol"] = "amqp"
 
         handshake = HTTP::Request.new("GET", "/", headers)
@@ -82,10 +69,6 @@ describe WebSocketTCPRelay::WebSocketProtocolHandler do
     it "should not be set if requested value is not configured" do
       with_relay(protocols: {"amqp"}) do |socket|
         headers : HTTP::Headers = HTTP::Headers.new
-        headers["Connection"] = "Upgrade"
-        headers["Upgrade"] = "websocket"
-        headers["Sec-WebSocket-Version"] = "13"
-        headers["Sec-WebSocket-Key"] = "random secret"
         headers["Sec-WebSocket-Protocol"] = "mqtt"
 
         handshake = HTTP::Request.new("GET", "/", headers)

--- a/spec/websocket-tcp-relay_spec.cr
+++ b/spec/websocket-tcp-relay_spec.cr
@@ -1,9 +1,4 @@
 require "./spec_helper"
 
 describe WebSocketTCPRelay::WebSocketRelay do
-  # TODO: Write tests
-
-  it "works" do
-    false.should eq(true)
-  end
 end

--- a/src/websocket-tcp-relay.cr
+++ b/src/websocket-tcp-relay.cr
@@ -12,6 +12,7 @@ module WebSocketTCPRelay
     upstream_uri = nil
     proxy_protocol = false
     prefix = "/"
+    sub_protocols = [] of String
 
     OptionParser.parse do |parser|
       parser.banner = "Usage: #{File.basename PROGRAM_NAME} [arguments]"
@@ -39,6 +40,9 @@ module WebSocketTCPRelay
       parser.on("--prefix=PATH", "Path prefix (default #{prefix})") do |v|
         prefix = v
       end
+      parser.on("--sub-protocols=protocols", "Comma separated list of protocols to accept in Sec-WebSocket-Protocol") do |v|
+        sub_protocols = v.split(",", remove_empty: true).map(&.strip)
+      end
       parser.on("-c PATH", "--config=PATH", "Config file") do |v|
         config = File.open(v) { |f| INI.parse(f) }
         config.each do |name, section|
@@ -54,6 +58,7 @@ module WebSocketTCPRelay
               when "proxy-protocol" then proxy_protocol = /^(true|1|on)$/.matches?(value)
               when "webroot"        then webroot = value
               when "prefix"         then prefix = value
+              when "sub-protocols"  then sub_protocols = value.split(",", remove_empty: true).map(&.strip)
               else                       abort "Unrecognized config: #{name}/#{key}"
               end
             end
@@ -82,6 +87,7 @@ module WebSocketTCPRelay
       MIME.register(".mjs", "text/javascript;charset=utf-8") # ecmascript modules
 
       server = HTTP::Server.new([
+        WebSocketProtocolHandler.new(sub_protocols),
         WebSocketRelay.new(u.host || "127.0.0.1", u.port || 5672, u.scheme == "tls", proxy_protocol),
         PrefixHandler.new(prefix),
         HTTP::StaticFileHandler.new(webroot, fallthrough: false, directory_listing: false),
@@ -104,6 +110,7 @@ module WebSocketTCPRelay
       puts "Upstream: #{u}"
       puts "PROXY protocol: #{proxy_protocol ? "enabled" : "disabled"}"
       puts "Web root: #{Dir.exists?(webroot) ? File.expand_path webroot : "Not found"}"
+      puts "Sub protocols: #{sub_protocols.join(", ")}"
       puts "Path: #{prefix}"
       Signal::INT.trap { server.close }
       Signal::TERM.trap { server.close }

--- a/src/websocket-tcp-relay/websocket_protocol_handler.cr
+++ b/src/websocket-tcp-relay/websocket_protocol_handler.cr
@@ -1,0 +1,25 @@
+require "http/server/handler"
+
+module WebSocketTCPRelay
+  class WebSocketProtocolHandler
+    include HTTP::Handler
+
+    def initialize(@protocols : Enumerable(String))
+    end
+
+    def call(context)
+      handle_sub_protocol(context)
+      call_next(context)
+    end
+
+    private def handle_sub_protocol(ctx)
+      valid_protocols = @protocols
+      return if valid_protocols.empty?
+      if protocols = ctx.request.headers.get?("Sec-WebSocket-Protocol")
+        if protocol = protocols.find { |p| valid_protocols.any? &.== p }
+          ctx.response.headers["Sec-WebSocket-Protocol"] = protocol
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds support for `Sec-WebSocket-Protocol`. It's configurable via ini config and cli options.

If configured the requested `Sec-WebSocket-Protocol` is looked up in the configured list of protocols. The first matching protocol is set as response `Sec-WebSocket-Protocol`.

Because of limitations in Crystal's `HTTP::WebSocketHandler` and how request upgrades are done, the solution is very basic and will always validate and set `Sec-WebSocket-Protocol` even if the request isn't a upgrade request. For the use case of `websocket-tcp-relay` it probably shouldn't matter.

Fixes #23