### PR TITLE
Build debs for 26.04 and trixie, stop building for 20.04 (EoL)

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -38,7 +38,7 @@ jobs:
           file: Dockerfile.deb
           platforms: linux/${{ matrix.arch }}
           build-args: |
-            build_image=84codes/crystal:1.13.3-${{ matrix.os }}
+            build_image=84codes/crystal:latest-${{ matrix.os }}
             pkg_version=${{ env.PKG_VERSION }}
           outputs: builds
 

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, debian-bullseye, debian-bookworm]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, debian-bullseye, debian-bookworm, debian-trixie]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/build/deb
+++ b/build/deb
@@ -3,11 +3,11 @@ pkg_version=${1:-$(git describe --tags | cut -c2- )}
 pkg_revision=${2:-1}
 architecture=$(dpkg --print-architecture)
 
+apt-get update && apt-get install libssl-dev dpkg-dev --yes
 shards build --production --release
 strip bin/*
 
 # dpkg-shlibdeps requires presence of `debian/control`
-apt-get update && apt-get install dpkg-dev --yes
 mkdir debian
 touch debian/control
 shlib_depends=$(dpkg-shlibdeps -O -e bin/* 2> /dev/null);


### PR DESCRIPTION
Tested by [manual dispatch](https://github.com/cloudamqp/websocket-tcp-relay/actions/runs/25304585576).