### PR TITLE
use hostname for upstream uri to allow for ipv6.

### DIFF
--- a/src/websocket-tcp-relay.cr
+++ b/src/websocket-tcp-relay.cr
@@ -82,7 +82,7 @@ module WebSocketTCPRelay
       MIME.register(".mjs", "text/javascript;charset=utf-8") # ecmascript modules
 
       server = HTTP::Server.new([
-        WebSocketRelay.new(u.host || "127.0.0.1", u.port || 5672, u.scheme == "tls", proxy_protocol),
+        WebSocketRelay.new(u.hostname || "127.0.0.1", u.port || 5672, u.scheme == "tls", proxy_protocol),
         PrefixHandler.new(prefix),
         HTTP::StaticFileHandler.new(webroot, fallthrough: false, directory_listing: false),
       ])


### PR DESCRIPTION
Currently when ipv6 is used as upstream (`[::1:5672`) we pass the brackets too, which fails during hostname lookup. sending only hostname fixes lookup.

before:
```
Jun 03 02:19:00 test-sweet-gold-koala-01 systemd[1]: Started websocket-tcp-relay.service - WebSocket TCP Relay.
Jun 03 02:19:00 test-sweet-gold-koala-01 websocket-tcp-relay[2740]: Listening: http://[::1]:15670
Jun 03 02:19:00 test-sweet-gold-koala-01 websocket-tcp-relay[2740]: Upstream: tcp://[::1]:5672
Jun 03 02:19:00 test-sweet-gold-koala-01 websocket-tcp-relay[2740]: PROXY protocol: disabled
Jun 03 02:19:00 test-sweet-gold-koala-01 websocket-tcp-relay[2740]: Web root: Not found
Jun 03 02:19:00 test-sweet-gold-koala-01 websocket-tcp-relay[2740]: Path: /
Jun 03 02:33:22 test-sweet-gold-koala-01 websocket-tcp-relay[2740]: 118.92.105.198:59856 connected
Jun 03 02:33:22 test-sweet-gold-koala-01 websocket-tcp-relay[2740]: 118.92.105.198:59856 disconnected: #<Socket::Addrinfo::Error:Hostname lookup for [::1] failed: No address found>
```

after:
```
Jun 03 02:28:24 test-cold-brown-swan-01 systemd[1]: Started websocket-tcp-relay.service - WebSocket TCP Relay.
Jun 03 02:28:24 test-cold-brown-swan-01 websocket-tcp-relay[25351]: Listening: http://[::1]:15670
Jun 03 02:28:24 test-cold-brown-swan-01 websocket-tcp-relay[25351]: Upstream: tcp://[::1]:5672
Jun 03 02:28:24 test-cold-brown-swan-01 websocket-tcp-relay[25351]: PROXY protocol: disabled
Jun 03 02:28:24 test-cold-brown-swan-01 websocket-tcp-relay[25351]: Web root: Not found
Jun 03 02:28:24 test-cold-brown-swan-01 websocket-tcp-relay[25351]: Path: /
Jun 03 02:28:32 test-cold-brown-swan-01 websocket-tcp-relay[25351]: 118.92.105.198:59745 connected
Jun 03 02:28:32 test-cold-brown-swan-01 websocket-tcp-relay[25351]: 118.92.105.198:59745 connected to upstream
```

internal slack thread: 
https://84codes.slack.com/archives/C04EBKB2N2K/p1780448347921129?thread_ts=1779379535.264319&cid=C04EBKB2N2K

https://crystal-lang.org/api/1.20.2/URI.html#hostname%3AString%7CNil-instance-method