### PR TITLE
Bump version to 1.0.9

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: websocket-tcp-relay
-version: 1.0.8
+version: 1.0.9
 
 authors:
   - Carl Hörberg <carl@cloudamqp.com>


### PR DESCRIPTION
Bumps `version:` in `shard.yml` to 1.0.9 so the compiled binary's `--version` matches the next release tag.

## Unreleased changes that will ship in 1.0.9
- IPv6 upstream fix: strip brackets via `u.hostname` (`30b532a`)
- deb build image floated to `latest` per distro; added 26.04/trixie, dropped EoL 20.04 (`17182c8`)
- README install instructions, CODEOWNERS, `.gitignore` housekeeping

## Verified
Built the `.deb` locally and tested on a dev host (ubuntu 24) end-to-end: external bind, WebSocket upgrade, AMQP upstream connect, and a publish via `amqp-client.js` all succeeded.



